### PR TITLE
Add interpolations to existing regex matching on mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,6 @@ npx local-traffic
 9. Your page will use /jquery-local/jquery.js instead of the CDN asset, and will serve the file from your hard drive
 10. Your server now proxies the mapping that you have configured
 
-## String Interpolations
-Mappings support regular expressions, and are able to match them against the destination through string interpolation. They match a double dollar sign (`$$`) followed by the index of the value in the [match array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value).
-
-For example:
-```json
-{
-  "mappings": {
-    "/(example|test)": "http://example.com/$$1"
-  }
-}
-```
-
-Would map both "/example" and "/test" to "http://example.com/example" and "http://example.com/test" respectively.
-
 ## usage
 
 ### from your terminal, using the command line
@@ -89,6 +75,20 @@ npx local-traffic [location-of-the-local-traffic-config-file]
 1. Open `.local-traffic.json` while running it, or use the config web editor
 2. Edit the mapping keys and downstream urls
 3. See the status update in the terminal, that's it.
+
+## mapping string interpolations (>=0.0.89) 
+The `mapping` entries support regular expressions, and are able to match them against the destination through string interpolation. They match a double dollar sign (`$$`) followed by the index of the value in the [match array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value).
+
+For example:
+```json
+{
+  "mappings": {
+    "/(example|test)": "http://example.com/$$1"
+  }
+}
+```
+
+Would map both "/example" and "/test" to "http://example.com/example" and "http://example.com/test" respectively.
 
 ## all the options
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For example:
 }
 ```
 
-Woould map both "/example" and "/test" to "http://example.com/example" and "http://example.com/test" respectively.
+Would map both "/example" and "/test" to "http://example.com/example" and "http://example.com/test" respectively.
 
 ## usage
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ npx local-traffic
 9. Your page will use /jquery-local/jquery.js instead of the CDN asset, and will serve the file from your hard drive
 10. Your server now proxies the mapping that you have configured
 
+## String Interpolations
+Mappings support regular expressions, and are able to match them against the destination through string interpolation. They match a double dollar sign (`$$`) followed by the index of the value in the [match array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value).
+
+For example:
+```json
+{
+  "mappings": {
+    "/(example|test)": "http://example.com/$$1"
+  }
+}
+```
+
+Woould map both "/example" and "/test" to "http://example.com/example" and "http://example.com/test" respectively.
+
 ## usage
 
 ### from your terminal, using the command line

--- a/index.ts
+++ b/index.ts
@@ -1991,23 +1991,20 @@ const determineMapping = (
     ),
   };
 
-  let key : string | undefined;
-  let target : URL | undefined;
+  let match: RegExpMatchArray | undefined;
+  const [key, rawTarget] =
+    Object.entries(mappings).find(
+      ([key]) => (match = path.match(RegExp(key.replace(/^\//, "^/")))),
+    ) ?? [];
 
-  for(const [pattern, url] of Object.entries(mappings)) {
-    const match = path.match(RegExp(pattern.replace(/^\//, "^/")));
-    if(match) {
-      key = pattern;
-
-      // extract the matched values from the path
-      const matchedValues = match.slice(1);
-
-      // interpolate the matched values into the url
-      target = new URL(interpolateString(url.href, matchedValues));
-      break;
-    }
-  }
-
+  const target = !match
+    ? null
+    : new URL(
+        rawTarget.href.replace(
+          /\$\$(\d+)/g,
+          (_, index) => match[parseInt(index)],
+        ),
+      );
   return { proxyHostname, proxyHostnameAndPort, url, path, key, target };
 };
 

--- a/index.ts
+++ b/index.ts
@@ -2008,10 +2008,6 @@ const determineMapping = (
   return { proxyHostname, proxyHostnameAndPort, url, path, key, target };
 };
 
-const interpolateString = (template: string, values: string[]) : string => {
-  return template.replace(/\$\$(\d+)/g, (_, index) => values[parseInt(index) - 1]);
-}
-
 const websocketServe = function (
   state: State,
   request: IncomingMessage,

--- a/index.ts
+++ b/index.ts
@@ -1991,12 +1991,29 @@ const determineMapping = (
     ),
   };
 
-  const [key, target] =
-    Object.entries(mappings).find(([key]) =>
-      path.match(RegExp(key.replace(/^\//, "^/"))),
-    ) ?? [];
+  let key : string | undefined;
+  let target : URL | undefined;
+
+  for(const [pattern, url] of Object.entries(mappings)) {
+    const match = path.match(RegExp(pattern.replace(/^\//, "^/")));
+    if(match) {
+      key = pattern;
+
+      // extract the matched values from the path
+      const matchedValues = match.slice(1);
+
+      // interpolate the matched values into the url
+      target = new URL(interpolateString(url.href, matchedValues));
+      break;
+    }
+  }
+
   return { proxyHostname, proxyHostnameAndPort, url, path, key, target };
 };
+
+const interpolateString = (template: string, values: string[]) : string => {
+  return template.replace(/\$\$(\d+)/g, (_, index) => values[parseInt(index) - 1]);
+}
 
 const websocketServe = function (
   state: State,


### PR DESCRIPTION
Hello, here's a small change for the ability to insert matched strings from the regex on a given mapping into the destination URL. It's not a huge change, but allows for more consise (and less duplicated) mappings.

A minimal example config:
```json
{
    "mapping": {
     "/(.*)/(local-traffic|example)$": "https://www.google.com/search?&q=site:github.com+$$1+$$2",
     "/(mdbell|libetl)": "https://github.com/$$1"
    }
  }
```
