### PR TITLE
unwantedHeaderNamesInMocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ All boolean settings default to false when unspecified.
 - `disableWebSecurity`: (`boolean`) true for easygoing values in cross origin requests or content security policy headers
 - `connectTimeout`: (`number`) max time before aborting the connection (defaults to 3000ms)
 - `socketTimeout`: (`number`) max time waiting for a response (defaults to 3000ms)
+- `unwantedHeaderNamesInMocks`: (`string[]`) header names that won't get added to the mock request matchers
 
 ## recorder API
 

--- a/index.ts
+++ b/index.ts
@@ -100,6 +100,7 @@ interface LocalConfiguration {
   mapping?: Mapping;
   ssl?: SecureServerOptions;
   port?: number;
+  unwantedHeaderNamesInMocks?: string[];
   replaceRequestBodyUrls?: boolean;
   replaceResponseBodyUrls?: boolean;
   dontUseHttp2Downstream?: boolean;
@@ -728,15 +729,17 @@ const configPage = (proxyHostnameAndPort: string, state: State) =>
         ${Object.entries({ ...defaultConfig, ssl: { cert: "", key: "" } })
           .map(
             ([property, exampleValue]) =>
-              `${property}: {type: "${
-                typeof exampleValue === "number"
-                  ? "integer"
-                  : typeof exampleValue === "string"
-                    ? "string"
-                    : typeof exampleValue === "boolean"
-                      ? "boolean"
-                      : "object"
-              }"}`,
+              `${property}: {type: ${
+                property === "unwantedHeaderNamesInMocks"
+                  ? '"array","items": {"type":"string"}'
+                  : typeof exampleValue === "number"
+                    ? '"integer"'
+                    : typeof exampleValue === "string"
+                      ? '"string"'
+                      : typeof exampleValue === "boolean"
+                        ? '"boolean"'
+                        : '"object"'
+              }}`,
           )
           .join(",\n          ")}
       },
@@ -860,7 +863,7 @@ const recorderHandler = (
     ? null
     : new Map<string, string>(
         mocksArray.map(({ response, uniqueHash }) => [
-          cleanEntropy(uniqueHash),
+          cleanEntropy(state.config, uniqueHash),
           response,
         ]),
       );
@@ -1665,6 +1668,7 @@ const defaultConfig: Required<Omit<LocalConfiguration, "ssl">> &
   disableWebSecurity: false,
   connectTimeout: 3000,
   socketTimeout: 3000,
+  unwantedHeaderNamesInMocks: [],
 };
 const load = async (firstTime: boolean = true): Promise<LocalConfiguration> =>
   new Promise<LocalConfiguration>(resolve =>
@@ -1707,22 +1711,24 @@ const load = async (firstTime: boolean = true): Promise<LocalConfiguration> =>
           filename,
           JSON.stringify(defaultConfig, null, 2),
           fileWriteErr => {
-            return (fileWriteErr ?
-              log(null, [
-                [
-                  {
-                    text: `${EMOJIS.ERROR_4} config file NOT created`,
-                    color: LogLevel.ERROR,
-                  },
-                ],
-              ]) : log(null, [
-                [
-                  {
-                    text: `${EMOJIS.COLORED} config file created`,
-                    color: LogLevel.INFO,
-                  },
-                ],
-              ])
+            return (
+              fileWriteErr
+                ? log(null, [
+                    [
+                      {
+                        text: `${EMOJIS.ERROR_4} config file NOT created`,
+                        color: LogLevel.ERROR,
+                      },
+                    ],
+                  ])
+                : log(null, [
+                    [
+                      {
+                        text: `${EMOJIS.COLORED} config file created`,
+                        color: LogLevel.INFO,
+                      },
+                    ],
+                  ])
             ).then(() => resolve(config!));
           },
         );
@@ -2225,7 +2231,10 @@ const replaceTextUsingMapping = (
     .split(`${proxyHostnameAndPort}/:`)
     .join(`${proxyHostnameAndPort}:`);
 
-const cleanEntropy = (requestObject: string | RequestStruct) => {
+const cleanEntropy = (
+  config: LocalConfiguration,
+  requestObject: string | RequestStruct,
+) => {
   try {
     const request =
       typeof requestObject === "object"
@@ -2267,6 +2276,9 @@ const cleanEntropy = (requestObject: string | RequestStruct) => {
       // disable unwanted security check
       "user-agent",
       // no user agent comparison
+      ...(Array.isArray(config.unwantedHeaderNamesInMocks)
+        ? config.unwantedHeaderNamesInMocks
+        : []),
     ].forEach(header => {
       delete request?.headers?.[header];
     });
@@ -2680,7 +2692,7 @@ const serve = async function (
   );
   const autoRecordModeEnabled =
     state.mockConfig.autoRecord && state.mode === ServerMode.PROXY;
-  const uniqueHash = cleanEntropy({
+  const uniqueHash = cleanEntropy(state.config, {
     method: inboundRequest.method ?? "GET",
     url: inboundRequest.url ?? "",
     headers: Object.assign(
@@ -2760,7 +2772,9 @@ const serve = async function (
               mockRequestObject.body === requestObject.body) &&
             Object.entries(mockRequestObject.headers ?? {}).every(
               ([name, value]) =>
-                !value || requestObject.headers?.[name] === value,
+                !value ||
+                state.config?.unwantedHeaderNamesInMocks?.includes?.(name) ||
+                requestObject.headers?.[name] === value,
             )
           );
         })

--- a/test/tests.spec.mjs
+++ b/test/tests.spec.mjs
@@ -560,6 +560,7 @@ describe("server cruise", async () => {
       `request=${JSON.stringify({
         method: "GET",
         headers: {
+          "content-length": "83",
           host: "localhost",
         },
         url: "/foo/bar",

--- a/test/tests.spec.mjs
+++ b/test/tests.spec.mjs
@@ -108,6 +108,7 @@ describe("config load", async () => {
       simpleLogs: false,
       logAccessInTerminal: false,
       websocket: true,
+      unwantedHeaderNamesInMocks: [],
       disableWebSecurity: false,
     });
   });
@@ -135,6 +136,7 @@ describe("config load", async () => {
       dontTranslateLocationHeader: false,
       simpleLogs: false,
       logAccessInTerminal: false,
+      unwantedHeaderNamesInMocks: [],
       websocket: true,
       disableWebSecurity: false,
     });
@@ -161,6 +163,7 @@ describe("config load", async () => {
       simpleLogs: false,
       logAccessInTerminal: false,
       websocket: true,
+      unwantedHeaderNamesInMocks: [],
       disableWebSecurity: false,
     });
   });
@@ -192,6 +195,7 @@ describe("config load", async () => {
       dontTranslateLocationHeader: false,
       simpleLogs: false,
       logAccessInTerminal: false,
+      unwantedHeaderNamesInMocks: [],
       websocket: true,
       disableWebSecurity: false,
     });
@@ -244,6 +248,7 @@ describe("config load", async () => {
       simpleLogs: true,
       logAccessInTerminal: true,
       websocket: false,
+      unwantedHeaderNamesInMocks: [],
       disableWebSecurity: true,
     });
   });
@@ -871,6 +876,51 @@ describe('Mock server matcher', () => {
       url: '/',
       headers: {
         'X-My-Header': 'My-Value',
+        host: 'example.com'
+      },
+      readableLength: 0,
+    }, {
+      writeHead: () => { },
+      end: (payload) => {
+        body = payload.toString("ascii")
+      }
+    })
+    assert.equal(body, "matched a mock");
+  })
+
+  it('should match when the request uses a header that is different but unwanted', async () => {
+    let body = ''
+    await serve({
+      config: {
+        port: 1337,
+        mapping: {},
+        unwantedHeaderNamesInMocks: ['X-My-Excluded-Header']
+      },
+      mockConfig: {
+        autoRecord: true,
+        strict: true,
+        mocks: new Map([[
+          Buffer.from(JSON.stringify({
+            method: "GET",
+            url: "/",
+            headers: { host: 'example.com', 'X-My-Excluded-Header': 'Value-1' },
+            body: ""
+          })).toString("base64"),
+          Buffer.from(JSON.stringify({
+            body:
+              Buffer.from("matched a mock").toString('base64')
+          })).toString("base64")
+        ]])
+      },
+      logsListeners: [],
+      mode: 'mock',
+      log: () => { },
+      notifyLogsListeners: () => { }
+    }, {
+      method: 'GET',
+      url: '/',
+      headers: {
+        'X-My-Excluded-Header': 'Value-2',
         host: 'example.com'
       },
       readableLength: 0,


### PR DESCRIPTION
`unwantedHeaderNamesInMocks` is an option to avoid including some header names while trying to match a mock, that are non-standard, but that are still part of the request entropy.